### PR TITLE
Fixed deprecated code, and fixed the commentwall

### DIFF
--- a/actions/commentwall/add.php
+++ b/actions/commentwall/add.php
@@ -11,19 +11,19 @@ $user = get_entity($profile_guid);
 if ($user && !empty($message)) {
 
 	// If posting the comment was successful, say so
-	if ($user->annotate('commentwall', $message, ACCESS_PUBLIC, get_loggedin_userid())) {
+	if ($user->annotate('commentwall', $message, ACCESS_PUBLIC, elgg_get_logged_in_user_guid())) {
 
-			if ($profile_guid != get_loggedin_userid()) {
+			if ($profile_guid != elgg_get_logged_in_user_guid()) {
 				notify_user(
 					$profile_guid,
-					get_loggedin_userid(),
+					elgg_get_logged_in_user_guid(),
 					elgg_echo('profile:comment:subject'),
 					elgg_echo('profile:comment:body', array(
-						get_loggedin_user()->name,
+						elgg_get_logged_in_user_entity()->name,
 						$message,
 						$user->getURL(),
-						get_loggedin_user()->name,
-						get_loggedin_user()->getURL()
+						elgg_get_logged_in_user_entity()->name,
+						elgg_get_logged_in_user_entity()->getURL()
 					))
 				);
 			}
@@ -33,7 +33,7 @@ if ($user && !empty($message)) {
 			add_to_river(
 					'river/object/profile/commentwall/create',
 					'commentwall',
-					get_loggedin_userid(),
+					elgg_get_logged_in_user_guid(),
 					$profile_guid);
 	} else {
 		register_error(elgg_echo("profile:commentwall:failure"));

--- a/actions/commentwall/delete.php
+++ b/actions/commentwall/delete.php
@@ -3,9 +3,9 @@
  * Delete wall comment
  */
 		
-$annotation_id = (int) get_input('id');
+$annotation_id = (int)get_input('annotation_id');
 
-$comment = get_annotation($annotation_id);
+$comment = elgg_get_annotation_from_id($annotation_id);
 if ($comment && $comment->canEdit()) {
 	$comment->delete();
 	system_message(elgg_echo('profile:commentwall:deleted'));

--- a/start.php
+++ b/start.php
@@ -38,6 +38,9 @@ function tabbed_profile_init() {
 	elgg_register_action("commentwall/add", "$action_base/add.php");
 	elgg_register_action("commentwall/delete", "$action_base/delete.php");
 
+	// Register a menu handler for commentwall annotations
+	elgg_register_plugin_hook_handler('register', 'menu:annotation', 'tabbed_profile_annotation_menu_setup');
+
 	// allow ECML in parts of the profile
 	elgg_register_plugin_hook_handler('get_views', 'ecml', 'tabbed_profile_ecml_views_hook');
 }
@@ -134,4 +137,29 @@ function tabbed_profile_ecml_views_hook($hook, $entity_type, $return_value, $par
 	$return_value['profile/profile_content'] = elgg_echo('profile');
 
 	return $return_value;
+}
+
+/**
+ * Adds a delete link to "commentwall" annotations
+ * @access private
+ */
+function tabbed_profile_annotation_menu_setup($hook, $type, $return, $params) {
+	$annotation = $params['annotation'];
+
+	if ($annotation->name == 'commentwall' && $annotation->canEdit()) {
+		$url = elgg_http_add_url_query_elements('action/commentwall/delete', array(
+			'annotation_id' => $annotation->id,
+		));
+
+		$options = array(
+			'name' => 'delete',
+			'href' => $url,
+			'text' => "<span class=\"elgg-icon elgg-icon-delete\"></span>",
+			'confirm' => elgg_echo('deleteconfirm'),
+			'encode_text' => false
+		);
+		$return[] = ElggMenuItem::factory($options);
+	}
+
+	return $return;
 }

--- a/views/default/annotation/commentwall.php
+++ b/views/default/annotation/commentwall.php
@@ -1,41 +1,10 @@
 <?php
 /**
- * Comment wall annotation view
+ * Elgg commentwall annotation view
+ * - Just outputs the regular generic_comment view for consistency
  *
- * @uses $vars['annotation']
+ * @uses $vars['annotation']  ElggAnnotation object
+ * @uses $vars['full_view']   Display fill view or brief view
  */
 
-$annotation = $vars['annotation'];
-$poster = $annotation->getOwnerEntity();
-$date = elgg_view_friendly_time($annotation->time_created);
-
-$icon = elgg_view('profile/icon', array(
-	'entity' => $poster,
-	'size' => 'tiny',
-));
-
-$delete_url = "action/commentwall/delete?id=$annotation->id";
-$delete_link = elgg_view('output/confirmlink', array(
-	'href' => $delete_url,
-	'text' => '<span class="elgg-icon elgg-icon-delete"></span>',
-	'title' => elgg_echo('delete'),
-	'confirm' => elgg_echo('deleteconfirm'),
-	'text_encode' => false,
-));
-
-$metadata = <<<HTML
-<ul class="elgg-list-metadata">
-	<li>$delete_link</li>
-</ul>
-HTML;
-
-$subtext = "$poster->name $date";
-$content = elgg_view('output/longtext', array('value' => $annotation->value));
-
-$body = <<<HTML
-$metadata
-<p class="elgg-subtext">$subtext</p>
-$content
-HTML;
-
-echo elgg_view_image_block($icon, $body);
+echo elgg_view('annotation/generic_comment', $vars);

--- a/views/default/forms/commentwall/add.php
+++ b/views/default/forms/commentwall/add.php
@@ -5,10 +5,10 @@
 
 echo '<div class="clearfix">';
 
-echo elgg_view('input/plaintext', array('internalname' => 'message'));
+echo elgg_view('input/plaintext', array('name' => 'message'));
 
 echo elgg_view('input/hidden', array(
-	'internalname' => 'profile_guid',
+	'name' => 'profile_guid',
 	'value' => elgg_get_page_owner_guid(),
 ));
 

--- a/views/default/profile/owner_block.php
+++ b/views/default/profile/owner_block.php
@@ -11,7 +11,7 @@ if (!$user) {
 	return TRUE;
 }
 
-$icon = elgg_view_entity_icon($user, 'large', array('override' => 'true'));
+$icon = elgg_view_entity_icon($user, 'large', array('user_hover' => TRUE));
 
 // grab the actions and admin menu items from user hover
 $menu = elgg_trigger_plugin_hook('register', "menu:user_hover", array('entity' => $user), array());


### PR DESCRIPTION
Just some code updates, and fixed the commentwall while I was at it. The 'commentwall' annotations now just use the regular 'generic_comment' view.. Just had to add a plugin hook to add the delete button for 'commentwall' annotations. 
